### PR TITLE
Fix some paths for linux

### DIFF
--- a/generate_emu_config_old/external_components/ach_watcher_gen.py
+++ b/generate_emu_config_old/external_components/ach_watcher_gen.py
@@ -178,6 +178,6 @@ def generate_all_ach_watcher_schemas(
             json.dump(out_schema, f, ensure_ascii=False, indent=2)
 
     shutil.make_archive(os.path.join(base_out_dir, "steam_misc\\extra_acw"), 'zip', os.path.join(base_out_dir, "steam_misc\\extra_acw")) # first argument is the name of the zip file
-    shutil.rmtree(os.path.join(base_out_dir, "steam_misc\\extra_acw"))
-    os.makedirs(os.path.join(base_out_dir, "steam_misc\\extra_acw"))
-    shutil.move(os.path.join(base_out_dir, 'steam_misc\\extra_acw.zip'), os.path.join(base_out_dir, "steam_misc\\extra_acw\\extra_acw.zip"))
+    shutil.rmtree(os.path.join(base_out_dir, "steam_misc", "extra_acw"))
+    os.makedirs(os.path.join(base_out_dir, "steam_misc", "extra_acw"))
+    shutil.move(os.path.join(base_out_dir, 'steam_misc', 'extra_acw.zip'), os.path.join(base_out_dir, "steam_misc", "extra_acw", "extra_acw.zip"))

--- a/generate_emu_config_old/external_components/ach_watcher_gen.py
+++ b/generate_emu_config_old/external_components/ach_watcher_gen.py
@@ -177,7 +177,7 @@ def generate_all_ach_watcher_schemas(
         with open(out_schema_file, "wt", encoding='utf-8') as f:
             json.dump(out_schema, f, ensure_ascii=False, indent=2)
 
-    shutil.make_archive(os.path.join(base_out_dir, "steam_misc\\extra_acw"), 'zip', os.path.join(base_out_dir, "steam_misc\\extra_acw")) # first argument is the name of the zip file
+    shutil.make_archive(os.path.join(base_out_dir, "steam_misc", "extra_acw"), 'zip', os.path.join(base_out_dir, "steam_misc", "extra_acw")) # first argument is the name of the zip file
     shutil.rmtree(os.path.join(base_out_dir, "steam_misc", "extra_acw"))
     os.makedirs(os.path.join(base_out_dir, "steam_misc", "extra_acw"))
     shutil.move(os.path.join(base_out_dir, 'steam_misc', 'extra_acw.zip'), os.path.join(base_out_dir, "steam_misc", "extra_acw", "extra_acw.zip"))

--- a/generate_emu_config_old/generate_emu_config.py
+++ b/generate_emu_config_old/generate_emu_config.py
@@ -1233,7 +1233,7 @@ def main():
             root_def_dir = os.path.join(get_exe_dir(False), "_DEFAULT")
 
         emu_settings_dir = os.path.join(base_out_dir, "steam_settings")
-        info_out_dir = os.path.join(base_out_dir, "steam_misc\\app_info")
+        info_out_dir = os.path.join(base_out_dir, "steam_misc", "app_info")
 
         print(f"[ ] DEF_DIR = {root_def_dir.replace(user_name, user_repl, 1)}")
         if RELATIVE_DIR and (RELATIVE_set == 'raw'):
@@ -1254,7 +1254,7 @@ def main():
                 while base_dir_path.exists():
                     time.sleep(0.05)
 
-        root_backup_dir = os.path.join(base_out_dir, "steam_misc\\app_backup")
+        root_backup_dir = os.path.join(base_out_dir, "steam_misc", "app_backup")
         #backup_dir = os.path.join(root_backup_dir, f"{appid}")
         backup_dir = root_backup_dir #use different structure for 'backup' dir
 
@@ -1798,12 +1798,12 @@ def main():
                     break
         '''
 
-        if os.path.isdir(os.path.join(base_out_dir, 'steam_misc\\app_backup')):
-            if os.listdir(os.path.join(base_out_dir, 'steam_misc\\app_backup')): # zip 'app_backup' folder only if not empty
-                shutil.make_archive(os.path.join(base_out_dir, 'steam_misc\\app_backup'), 'zip', os.path.join(base_out_dir, 'steam_misc\\app_backup')) # first argument is the name of the zip file
-                shutil.rmtree(os.path.join(base_out_dir, 'steam_misc\\app_backup'))
-                os.makedirs(os.path.join(base_out_dir, 'steam_misc\\app_backup'))
-                shutil.move(os.path.join(base_out_dir, 'steam_misc\\app_backup.zip'), os.path.join(base_out_dir, 'steam_misc\\app_backup\\app_backup.zip'))
+        if os.path.isdir(os.path.join(base_out_dir, 'steam_misc', 'app_backup')):
+            if os.listdir(os.path.join(base_out_dir, 'steam_misc', 'app_backup')): # zip 'app_backup' folder only if not empty
+                shutil.make_archive(os.path.join(base_out_dir, 'steam_misc', 'app_backup'), 'zip', os.path.join(base_out_dir, 'steam_misc', 'app_backup')) # first argument is the name of the zip file
+                shutil.rmtree(os.path.join(base_out_dir, 'steam_misc', 'app_backup'))
+                os.makedirs(os.path.join(base_out_dir, 'steam_misc', 'app_backup'))
+                shutil.move(os.path.join(base_out_dir, 'steam_misc', 'app_backup.zip'), os.path.join(base_out_dir, 'steam_misc', 'app_backup', 'app_backup.zip'))
 
         if DOWNLOAD_COMMON_IMAGES:
             app_images.download_app_images(


### PR DESCRIPTION
In short, currently some paths are specified as, for example: `os.path.join(base_out_dir, "steam_misc\\app_info")`. This is incompatible with linux, so I changed them for `os.path.join(base_out_dir, "steam_misc", "app_info")`, to continue with the same example.

Note that I fixed what wasn't working for my usecase. Maybe there's some problems of the same type somewhere else in the code, I admit I'm to lazy to check & fix everything. Maybe later? Still, these small modifications are better than nothing.